### PR TITLE
include requirements.txt in MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,5 @@
 include LICENSE.txt
 include README.md
+include requirements.txt
 recursive-include demo *
 recursive-include test *


### PR DESCRIPTION
Without including the `requirements.txt` in the `MANIFEST.in` the installation via pip fails.